### PR TITLE
Fixup Docu time.rst

### DIFF
--- a/Doc/library/time.rst
+++ b/Doc/library/time.rst
@@ -299,6 +299,11 @@ Functions
    Use :func:`monotonic_ns` to avoid the precision loss caused by the
    :class:`float` type.
 
+   .. impl-detail::
+
+      On CPython, use the same clock as :func:`time.perf_counter` and is a
+      monotonic clock, i.e. a clock that cannot go backwards.
+
    .. versionadded:: 3.3
 
    .. versionchanged:: 3.5
@@ -307,12 +312,20 @@ Functions
    .. versionchanged:: 3.10
       On macOS, the function is now system-wide.
 
+   .. versionchanged:: 3.13
+      Use the same clock as :func:`time.perf_counter`. On Windows, :func:`monotonic`
+      now call ``QueryPerformanceCounter()`` which has a resolution of 1 microsecond,
+      instead of the ``GetTickCount64()`` clock like in previous versions, which has
+      a resolution of 15.625 milliseconds.
 
 .. function:: monotonic_ns() -> int
 
    Similar to :func:`monotonic`, but return time as nanoseconds.
 
    .. versionadded:: 3.7
+
+   .. versionchanged:: 3.13
+      Use the same clock as :func:`time.perf_counter`.
 
 .. function:: perf_counter() -> float
 
@@ -325,11 +338,6 @@ Functions
    point of the returned value is undefined, so that only the difference between
    the results of two calls is valid.
 
-   .. impl-detail::
-
-      On CPython, use the same clock as :func:`time.monotonic` and is a
-      monotonic clock, i.e. a clock that cannot go backwards.
-
    Use :func:`perf_counter_ns` to avoid the precision loss caused by the
    :class:`float` type.
 
@@ -337,10 +345,6 @@ Functions
 
    .. versionchanged:: 3.10
       On Windows, the function is now system-wide.
-
-   .. versionchanged:: 3.13
-      Use the same clock as :func:`time.monotonic`.
-
 
 .. function:: perf_counter_ns() -> int
 
@@ -699,13 +703,18 @@ Functions
 
    Clock:
 
-   * On Windows, call ``GetSystemTimeAsFileTime()``.
+   * On Windows, call ``GetSystemTimePreciseAsFileTime()``.
    * Call ``clock_gettime(CLOCK_REALTIME)`` if available.
    * Otherwise, call ``gettimeofday()``.
 
    Use :func:`time_ns` to avoid the precision loss caused by the :class:`float`
    type.
 
+  .. versionchanged:: 3.13
+     On Windows, :func:`.time` now uses the ``GetSystemTimePreciseAsFileTime()``
+     clock for a resolution of 1 microsecond, instead of the
+     ``GetSystemTimeAsFileTime()`` clock which has a resolution of
+     15.625 milliseconds.
 
 .. function:: time_ns() -> int
 


### PR DESCRIPTION
- Fix Typo: On Windows, the _.time_ functions now use _GetSystemTime**Precise**AsFileTime()_ [--> 1 microsecond resolution] instead of _GetSystemTimeAsFileTime()_ [--> 15.625 millisecond resolution].
- On Windows, the _.monotonic_ functions now use the same clock as the _.perf_counter_ functions, **not vice versa**. The _.perf_counter_ functions previously already used _QueryPerformanceCounter()_ + _QueryPerformanceFrequency()_ [--> 1 microsecond resolution], whereas the _.monotonic_ functions previously used _GetTickCount64()_ [--> 15.625 millisecond resolution].

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->
